### PR TITLE
Update more-info-needed-closer.yml

### DIFF
--- a/.github/workflows/more-info-needed-closer.yml
+++ b/.github/workflows/more-info-needed-closer.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2
+      
+      # Add a step to wait for a specific time to avoid rate limiting
+      - name: Wait to avoid rate limit
+        run: sleep 120
+
       - name: Install Actions
         run: cd ./.github/actions && npm install --production && cd ../..
       - name: Stale Closer


### PR DESCRIPTION
This update adds a rate limiting step to the "More Info Needed Closer" GitHub Actions workflow. The new step ensures the workflow waits for 2 minutes (sleep 120) before proceeding to avoid exceeding GitHub's secondary rate limits. This helps to prevent the "You have exceeded a secondary rate limit" error, ensuring smoother execution of the workflow.